### PR TITLE
fix: GitHub Actions warning for Ubuntu version

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -70,7 +70,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: build
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
Change Ubuntu image version from "latest" to "24.04" in the deploy stage.

Closes #9