### PR TITLE
chore: bump Hugo, Blowfish, and drop deprecated config keys

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     env:
-      HUGO_VERSION: 0.153.0
+      HUGO_VERSION: 0.161.1
     steps:
       - name: Install Hugo CLI
         run: |

--- a/config/_default/languages.en.toml
+++ b/config/_default/languages.en.toml
@@ -1,6 +1,6 @@
 disabled = false
-languageCode = "en"
-languageName = "English"
+locale = "en"
+label = "English"
 weight = 1
 title = "Thoughts"
 

--- a/config/_default/languages.my.toml
+++ b/config/_default/languages.my.toml
@@ -1,6 +1,6 @@
 disabled = false
-languageCode = "my"
-languageName = "Burmese"
+locale = "my"
+label = "Burmese"
 weight = 2
 title = "Thoughts"
 

--- a/content/posts/2024110701/index.en.md
+++ b/content/posts/2024110701/index.en.md
@@ -2,7 +2,6 @@
 title = "Personal Blog Using Hugo and Blowfish"
 date = 2024-11-06T18:50:00+07:00
 draft = false
-lang = "en"
 slug = "personal-blog-using-hugo-and-blowfish"
 tags = ["hugo", "blowfish"]
 +++

--- a/content/posts/2024110701/index.my.md
+++ b/content/posts/2024110701/index.my.md
@@ -2,7 +2,6 @@
 title = "Hugo၊ Blowfish နဲ့ Personal Blog"
 date = 2024-11-06T18:50:00+07:00
 draft = false
-lang = "my"
 slug = "personal-blog-using-hugo-and-blowfish"
 tags = ["hugo", "blowfish"]
 +++

--- a/content/posts/2024122001/index.en.md
+++ b/content/posts/2024122001/index.en.md
@@ -2,7 +2,6 @@
 title = "Regular Expressions 101"
 date = '2024-12-20T02:41:08+07:00'
 draft = false
-lang = "en"
 slug = "regular-expressions-101"
 tags = ["regex", "python"]
 +++

--- a/content/posts/2024122001/index.my.md
+++ b/content/posts/2024122001/index.my.md
@@ -2,7 +2,6 @@
 title = "Regular Expressions အခြေခံ"
 date = '2024-12-29T02:41:08+07:00'
 draft = false
-lang = "my"
 slug = "regular-expressions-101"
 tags = ["regex", "python"]
 +++

--- a/content/posts/2025010501/index.en.md
+++ b/content/posts/2025010501/index.en.md
@@ -2,7 +2,6 @@
 title = "Regular Expressions 101 (Part 2)"
 date = '2025-01-08T22:24:00+07:00'
 draft = false
-lang = "en"
 slug = "regular-expressions-101-part-02"
 tags = ["regex", "python"]
 +++

--- a/content/posts/2025010501/index.my.md
+++ b/content/posts/2025010501/index.my.md
@@ -2,7 +2,6 @@
 title = "Regular Expressions အခြေခံ (အပိုင်း ၂)"
 date = '2025-01-05T02:38:00+07:00'
 draft = false
-lang = "my"
 slug = "regular-expressions-101-part-02"
 tags = ["regex", "python"]
 +++

--- a/content/posts/2025011001/index.en.md
+++ b/content/posts/2025011001/index.en.md
@@ -2,7 +2,6 @@
 title = "Cursor Pagination"
 date = '2025-01-12T23:07:00+07:00'
 draft = false
-lang = "en"
 slug = "cursor-pagination"
 tags = ["postgres", "mongodb", "sql", "nosql"]
 +++

--- a/content/posts/2025011001/index.my.md
+++ b/content/posts/2025011001/index.my.md
@@ -2,7 +2,6 @@
 title = "Cursor Pagination"
 date = '2025-01-10T22:30:00+07:00'
 draft = false
-lang = "my"
 slug = "cursor-pagination"
 tags = ["postgres", "mongodb", "sql", "nosql"]
 +++

--- a/content/posts/2025012201/index.en.md
+++ b/content/posts/2025012201/index.en.md
@@ -2,7 +2,6 @@
 title = "Hot Reload in Go"
 date = '2025-01-22T03:19:00+07:00'
 draft = false
-lang = "en"
 slug = "hot-reload-in-go"
 tags = ["development", "go"]
 +++

--- a/content/posts/2025012201/index.my.md
+++ b/content/posts/2025012201/index.my.md
@@ -2,7 +2,6 @@
 title = "Hot Reload in Go"
 date = '2025-01-22T03:19:00+07:00'
 draft = false
-lang = "my"
 slug = "hot-reload-in-go"
 tags = ["development", "go"]
 +++

--- a/content/posts/2025121301/index.en.md
+++ b/content/posts/2025121301/index.en.md
@@ -2,7 +2,6 @@
 title = "Go Linter With GitHub Actions"
 date = '2025-12-16T23:04:19+07:00'
 draft = false
-lang = "en"
 slug = "go-linter-with-github-actions"
 tags = ["github-actions", "go"]
 +++

--- a/content/posts/2025121301/index.my.md
+++ b/content/posts/2025121301/index.my.md
@@ -2,7 +2,6 @@
 title = "Go Linter With GitHub Actions"
 date = '2025-12-13T22:59:00+07:00'
 draft = false
-lang = "my"
 slug = "go-linter-with-github-actions"
 tags = ["github-actions", "go"]
 +++

--- a/content/posts/2025122301/index.en.md
+++ b/content/posts/2025122301/index.en.md
@@ -2,7 +2,6 @@
 title = "Unit Test With GitHub Actions"
 date = '2025-12-29T23:19:00+07:00'
 draft = false
-lang = "en"
 slug = "unit-test-with-github-actions"
 tags = ["github-actions", "go"]
 +++

--- a/content/posts/2025122301/index.my.md
+++ b/content/posts/2025122301/index.my.md
@@ -2,7 +2,6 @@
 title = "Unit Test With GitHub Actions"
 date = '2025-12-23T23:54:00+07:00'
 draft = false
-lang = "my"
 slug = "unit-test-with-github-actions"
 tags = ["github-actions", "go"]
 +++

--- a/content/posts/2026010701/index.en.md
+++ b/content/posts/2026010701/index.en.md
@@ -2,7 +2,6 @@
 title = "UUID Generator With AI Agent"
 date = '2026-01-09T23:44:00+07:00'
 draft = false
-lang = "en"
 slug = "uuid-generator-with-ai-agent"
 tags = ["uuid", "react", "vite", "ai", "github-copilot"]
 +++

--- a/content/posts/2026010701/index.my.md
+++ b/content/posts/2026010701/index.my.md
@@ -2,7 +2,6 @@
 title = "UUID Generator With AI Agent"
 date = '2026-01-07T23:43:00+07:00'
 draft = false
-lang = "my"
 slug = "uuid-generator-with-ai-agent"
 tags = ["uuid", "react", "vite", "ai", "github-copilot"]
 +++

--- a/content/posts/2026030601/index.en.md
+++ b/content/posts/2026030601/index.en.md
@@ -2,7 +2,6 @@
 title = "How to Update Past Commits"
 date = '2026-03-06T22:53:52+07:00'
 draft = false
-lang = "en"
 slug = "update-past-commits"
 tags = ["git", "github", "version-control"]
 +++

--- a/content/posts/2026030601/index.my.md
+++ b/content/posts/2026030601/index.my.md
@@ -2,7 +2,6 @@
 title = "Past Commits တွေကို ဘယ်လို Update လုပ်မလဲ"
 date = '2026-03-06T22:53:52+07:00'
 draft = false
-lang = "my"
 slug = "update-past-commits"
 tags = ["git", "github", "version-control"]
 +++

--- a/content/posts/2026030901/index.en.md
+++ b/content/posts/2026030901/index.en.md
@@ -2,7 +2,6 @@
 title = "What to Do If GitHub Contributions Are Missing (gitmailmap)"
 date = '2026-03-09T22:00:40+07:00'
 draft = false
-lang = "en"
 slug = "github-contributions-missing-gitmailmap"
 tags = ["git", "github", "gitmailmap", "filter-repo"]
 +++

--- a/content/posts/2026030901/index.my.md
+++ b/content/posts/2026030901/index.my.md
@@ -2,7 +2,6 @@
 title = "GitHub မှာ Contribution တွေ မပေါ်ရင် ဘယ်လိုလုပ်မလဲ (gitmailmap)"
 date = '2026-03-09T22:00:40+07:00'
 draft = false
-lang = "my"
 slug = "github-contributions-missing-gitmailmap"
 tags = ["git", "github", "gitmailmap", "filter-repo"]
 +++

--- a/content/posts/2026031101/index.en.md
+++ b/content/posts/2026031101/index.en.md
@@ -2,7 +2,6 @@
 title = "How to Edit Git Commits (git reset --soft)"
 date = '2026-03-12T23:30:41+07:00'
 draft = false
-lang = "en"
 slug = "git-reset-soft-head-tips"
 tags = ["git", "github", "git reset", "tips"]
 +++

--- a/content/posts/2026031101/index.my.md
+++ b/content/posts/2026031101/index.my.md
@@ -2,7 +2,6 @@
 title = "Git Commit တွေကို ဘယ်လို ပြန်ပြင်မလဲ (git reset --soft)"
 date = '2026-03-12T22:10:49+07:00'
 draft = false
-lang = "my"
 slug = "git-reset-soft-head-tips"
 tags = ["git", "github", "git reset", "tips"]
 +++

--- a/content/posts/2026032401/index.en.md
+++ b/content/posts/2026032401/index.en.md
@@ -2,7 +2,6 @@
 title = "Why claude-replay is useful for Claude Code Users"
 date = '2026-03-24T23:00:00+07:00'
 draft = false
-lang = "en"
 slug = "claude-replay-for-claude-code"
 tags = ["claude", "claude code", "claude-replay", "tools"]
 +++

--- a/content/posts/2026032401/index.my.md
+++ b/content/posts/2026032401/index.my.md
@@ -2,7 +2,6 @@
 title = "Claude Code အသုံးပြုသူများအတွက် အသုံးဝင်မယ့် claude-replay အကြောင်း"
 date = '2026-03-24T23:00:00+07:00'
 draft = false
-lang = "my"
 slug = "claude-replay-for-claude-code"
 tags = ["claude", "claude code", "claude-replay", "tools"]
 +++

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module hugo
 
 go 1.25.5
 
-require github.com/nunocoracao/blowfish/v2 v2.98.0 // indirect
+require github.com/nunocoracao/blowfish/v2 v2.102.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/nunocoracao/blowfish/v2 v2.98.0 h1:2k/f19NwAlhEIq08WOOgbYB4LlzWF2YEhoDoflSH0eU=
-github.com/nunocoracao/blowfish/v2 v2.98.0/go.mod h1:4SkMc+Ht8gpQCwArqiHMBDP3soxi2OWuAhVney+cuyk=
+github.com/nunocoracao/blowfish/v2 v2.102.0 h1:I5OdyUy4gGOZo3IyhewUk55u8Johmoex7LrvboChie8=
+github.com/nunocoracao/blowfish/v2 v2.102.0/go.mod h1:4SkMc+Ht8gpQCwArqiHMBDP3soxi2OWuAhVney+cuyk=

--- a/hugo.toml
+++ b/hugo.toml
@@ -1,3 +1,3 @@
 baseURL = 'https://example.org/'
-languageCode = 'en-us'
+locale = 'en-us'
 title = 'My New Hugo Site'


### PR DESCRIPTION
## Summary
- Upgrade Hugo (0.153.0 → 0.161.1) and Blowfish theme (v2.98.0 → v2.102.0)
- Remove deprecated `lang` front matter from content and deprecated language config keys to align with current Hugo/Blowfish conventions

## Changes
- Hugo version bump in CI config
- Blowfish theme dependency bump
- Content front matter cleanup (`lang` key removed)
- Hugo language config keys updated

## Test plan
- [ ] CI build passes with the new Hugo version
- [ ] Site renders correctly with the updated Blowfish theme
- [ ] No warnings about deprecated config keys or front matter